### PR TITLE
changed AllowTcpForwarding and AllowAgentForwarding from yes to no

### DIFF
--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -211,11 +211,11 @@ describe 'check sshd_config' do
     end
 
     describe file('/etc/ssh/sshd_config') do
-        its(:content) { should match /^AllowTcpForwarding yes$/}
+        its(:content) { should match /^AllowTcpForwarding no$/}
     end
 
     describe file('/etc/ssh/sshd_config') do
-        its(:content) { should match /^AllowAgentForwarding yes$/}
+        its(:content) { should match /^AllowAgentForwarding no$/}
     end
 
     describe file('/etc/ssh/sshd_config') do


### PR DESCRIPTION
changed AllowTcpForwarding and AllowAgentForwarding from yes to no, because we changed the default attribute value to no in ssh-hardening

Signed-off-by: Patrick Meier patrick.meier111@googlemail.com
