### PR TITLE
relax permissions on /etc/ssh and files

### DIFF
--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -15,7 +15,7 @@ describe 'SSH owner, group and permissions' do
   end
 
   describe file('/etc/ssh') do
-    it { should be_mode 555 }
+    it { should be_mode 755 }
   end
 
   describe file('/etc/ssh/sshd_config') do
@@ -23,11 +23,11 @@ describe 'SSH owner, group and permissions' do
   end
 
   describe file('/etc/ssh/sshd_config') do
-    it { should be_mode 400 }
+    it { should be_mode 600 }
   end
 
   describe file('/etc/ssh/ssh_config') do
-    it { should be_mode 444 }
+    it { should be_mode 644 }
   end
 
 end


### PR DESCRIPTION
root can write anyway, even if the permissions strictly speaking don't allow this. moreover, we want root to write, in the default DAC based model, so open this up slightly

Signed-off-by: Dominik Richter dominik.richter@gmail.com
