### PR TITLE
bugfix: unlock user accounts during chef runs

### DIFF
--- a/default/roles/ssh.json
+++ b/default/roles/ssh.json
@@ -9,6 +9,7 @@
     },
     "run_list": [
         "recipe[chef-solo-search]",
+        "recipe[ssh-hardening::unlock]",
         "recipe[ssh-hardening::server]",
         "recipe[ssh-hardening::client]"
     ]


### PR DESCRIPTION
Locked user accounts lead the SSH login not to work anymore. For tests, unlock all user accounts before applying SSH hardening.

Signed-off-by: Dominik Richter dominik.richter@gmail.com
