### PR TITLE
remove options that only apply to SSH protocol version 1

### DIFF
--- a/default/serverspec/ssh_spec.rb
+++ b/default/serverspec/ssh_spec.rb
@@ -215,14 +215,6 @@ describe 'check sshd_config' do
   end
 
   describe file('/etc/ssh/sshd_config') do
-    its(:content) { should match(/^KeyRegenerationInterval 1h$/) }
-  end
-
-  describe file('/etc/ssh/sshd_config') do
-    its(:content) { should match(/^ServerKeyBits 2048$/) }
-  end
-
-  describe file('/etc/ssh/sshd_config') do
     its(:content) { should match(/^UseLogin no$/) }
   end
 
@@ -252,11 +244,6 @@ describe 'check sshd_config' do
 
   # DTAG SEC: Req 3.04-13 ; DTAG SEC: Req 3.04-14
   describe file('/etc/ssh/sshd_config') do
-    its(:content) { should match(/^RSAAuthentication yes$/) }
-  end
-
-  # DTAG SEC: Req 3.04-13 ; DTAG SEC: Req 3.04-14
-  describe file('/etc/ssh/sshd_config') do
     its(:content) { should match(/^PubkeyAuthentication yes$/) }
   end
 
@@ -267,11 +254,6 @@ describe 'check sshd_config' do
 
   describe file('/etc/ssh/sshd_config') do
     its(:content) { should match(/^IgnoreUserKnownHosts yes$/) }
-  end
-
-  # DTAG SEC: Req 3.04-17
-  describe file('/etc/ssh/sshd_config') do
-    its(:content) { should match(/^RhostsRSAAuthentication no$/) }
   end
 
   # DTAG SEC: Req 3.04-17


### PR DESCRIPTION
In reference to feedback here: https://github.com/TelekomLabs/chef-ssh-hardening/issues/57

Signed-off-by: Dominik Richter dominik.richter@gmail.com
