### PR TITLE
Remove the PAM deactivation enforcement

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -274,15 +274,6 @@ control 'sshd-25' do
   end
 end
 
-control 'sshd-26' do
-  impact 1.0
-  title 'Server: Disable PAM'
-  desc 'Avoid challenge-response and password-based authentications.'
-  describe sshd_config do
-    its('UsePAM') { should eq('no') }
-  end
-end
-
 control 'sshd-27' do
   impact 1.0
   title 'Server: Disable password-based authentication'


### PR DESCRIPTION
as PAM should be enabled per default on the most distros:
 - https://github.com/dev-sec/chef-ssh-hardening/issues/96
 - https://github.com/dev-sec/ansible-ssh-hardening/issues/23
 - https://github.com/dev-sec/puppet-ssh-hardening/issues/53