### PR TITLE
Add OpenSSH definitions for macOS

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -48,6 +48,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         ciphers = ciphers66
       end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        ciphers = ciphers53
+      when /10.10\./, /10.11\./, /10.12\./
+        ciphers = ciphers66
+      end
     end
 
     ciphers
@@ -82,6 +89,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /6\./
         kex = nil
       when /7\./
+        kex = kex66
+      end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        kex = kex59
+      when /10.10\./, /10.11\./, /10.12\./
         kex = kex66
       end
     end
@@ -119,6 +133,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /6\./
         macs = macs53
       when /7\./
+        macs = macs66
+      end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        macs = macs59
+      when /10.10\./, /10.11\./, /10.12\./
         macs = macs66
       end
     end


### PR DESCRIPTION
Originally running on macOS resulted in defaults being applied, even though current OS versions ship with newer OpenSSH versions.

Particularly specifying `kex59` for the SSH client was a problem, because it does not include `curve25519-sha256@libssh.org`.

_(dev-sec recipes/profiles do not seem to take macOS into consideration, but this one specifies `os-family: unix` and basically executes on Macs with no problems - ok, remembered, there's also a `root`-group requirement which does not pass, because macOS does not have this group, fix on the way)_