### PR TITLE
Add ssh_crypto definitions for macOS

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -31,7 +31,7 @@ control 'ssh-01' do
     it { should exist }
     it { should be_file }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
+    it { should be_grouped_into os[:family] == 'darwin' ? 'wheel' : 'root' }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -57,7 +57,7 @@ control 'sshd-04' do
     it { should exist }
     it { should be_directory }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
+    it { should be_grouped_into os[:family] == 'darwin' ? 'wheel' : 'root' }
     it { should be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }
@@ -77,7 +77,7 @@ control 'sshd-05' do
     it { should exist }
     it { should be_file }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
+    it { should be_grouped_into os[:family] == 'darwin' ? 'wheel' : 'root' }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should_not be_readable.by('group') }

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -19,7 +19,7 @@
 class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
   name 'ssh_crypto'
 
-  def valid_ciphers
+  def valid_ciphers # rubocop:disable Metrics/CyclomaticComplexity
     # define a set of default ciphers
     ciphers53 = 'aes256-ctr,aes192-ctr,aes128-ctr'
     ciphers66 = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
@@ -46,6 +46,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /6\./
         ciphers = ciphers53
       when /7\./
+        ciphers = ciphers66
+      end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        ciphers = ciphers53
+      when /10.10\./, /10.11\./, /10.12\./
         ciphers = ciphers66
       end
     end
@@ -84,6 +91,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         kex = kex66
       end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        kex = kex59
+      when /10.10\./, /10.11\./, /10.12\./
+        kex = kex66
+      end
     end
 
     kex
@@ -119,6 +133,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /6\./
         macs = macs53
       when /7\./
+        macs = macs66
+      end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        macs = macs59
+      when /10.10\./, /10.11\./, /10.12\./
         macs = macs66
       end
     end


### PR DESCRIPTION
Originally running on macOS resulted in defaults being applied, even though current OS versions ship with newer OpenSSH versions. Particularly specifying `kex59` for the SSH client was a problem, because it does not include `curve25519-sha256@libssh.org`.

Also macOS does not have `root` group, so adding a conditional for configuration directory and files 
to be grouped under `wheel` on macOS.

_(dev-sec recipes/profiles do not seem to take macOS into consideration, but this one specifies `os-family: unix` and basically executes on Macs with no problems)_

_(It also seems I could have amended my previous PR which did not pass RuboCop complexity check instead of closing it and creating a new one, sorry for confusion)_