### PR TITLE
Algorithm/Hostkey tests for different platforms

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -165,12 +165,7 @@ control 'sshd-14' do
   title 'Server: Specify SSH HostKeys'
   desc 'Specify HostKey for protection against Man-In-The-Middle Attacks'
   describe sshd_config do
-    its('HostKey') do
-      should eq [
-        '/etc/ssh/ssh_host_rsa_key',
-        '/etc/ssh/ssh_host_ecdsa_key'
-      ]
-    end
+    its('HostKey') { should cmp ssh_crypto.valid_hostkeys }
   end
 end
 

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -48,6 +48,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         ciphers = ciphers66
       end
+    when 'fedora'
+      ciphers = ciphers66
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -91,6 +93,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         kex = kex66
       end
+    when 'fedora'
+      kex = kex66
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -135,6 +139,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         macs = macs66
       end
+    when 'fedora'
+      macs = macs66
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -204,6 +210,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /7\./
         alg = alg66
       end
+    when 'fedora'
+      alg = alg66
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -50,6 +50,11 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'fedora'
       ciphers = ciphers66
+    when 'opensuse'
+      case inspec.os[:release]
+      when /13\.2/
+        ciphers = ciphers66
+      end
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -95,6 +100,11 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'fedora'
       kex = kex66
+    when 'opensuse'
+      case inspec.os[:release]
+      when /13\.2/
+        kex = kex66
+      end
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -141,6 +151,11 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'fedora'
       macs = macs66
+    when 'opensuse'
+      case inspec.os[:release]
+      when /13\.2/
+        macs = macs66
+      end
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./
@@ -212,6 +227,11 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'fedora'
       alg = alg66
+    when 'opensuse'
+      case inspec.os[:release]
+      when /13\.2/
+        alg = alg66
+      end
     when 'mac_os_x'
       case inspec.os[:release]
       when /10.9\./

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -19,7 +19,7 @@
 class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
   name 'ssh_crypto'
 
-  def valid_ciphers # rubocop:disable Metrics/CyclomaticComplexity
+  def valid_ciphers # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
     # define a set of default ciphers
     ciphers53 = 'aes256-ctr,aes192-ctr,aes128-ctr'
     ciphers66 = 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'
@@ -60,7 +60,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     ciphers
   end
 
-  def valid_kexs # rubocop:disable Metrics/CyclomaticComplexity
+  def valid_kexs # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
     # define a set of default KEXs
     kex66 = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex59 = 'diffie-hellman-group-exchange-sha256'
@@ -103,7 +103,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     kex
   end
 
-  def valid_macs # rubocop:disable Metrics/CyclomaticComplexity
+  def valid_macs # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
     # define a set of default MACs
     macs66 = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
     macs59 = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
@@ -173,5 +173,56 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     end
 
     ps
+  end
+
+  # return a list of valid algoriths for a current platform
+  def valid_algorithms # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    alg53 = %w(rsa)
+    alg60 = %w(rsa ecdsa)
+    alg66 = %w(rsa ecdsa ed25519)
+    alg = alg66 # probably its a best suitable set for everything unknown
+
+    case inspec.os[:name]
+    when 'ubuntu'
+      case inspec.os[:release]
+      when '12.04'
+        alg = alg53
+      when '14.04', '15.10', '16.04'
+        alg = alg66
+      end
+    when 'debian'
+      case inspec.os[:release]
+      when /7\./
+        alg = alg60
+      when /8\./
+        alg = alg66
+      end
+    when 'redhat', 'centos', 'oracle'
+      case inspec.os[:release]
+      when /6\./
+        alg = alg53
+      when /7\./
+        alg = alg66
+      end
+    when 'mac_os_x'
+      case inspec.os[:release]
+      when /10.9\./
+        alg53
+      when /10.10\./, /10.11\./, /10.12\./
+        alg66
+      end
+    end
+
+    alg
+  end
+
+  # returns the hostkeys value based on valid_algorithms
+  def valid_hostkeys
+    hostkeys = valid_algorithms.map { |alg| "/etc/ssh/ssh_host_#{alg}_key" }
+    # its('HostKey') provides a string for a single-element value.
+    # we have to return a string if we have a single-element
+    # https://github.com/chef/inspec/issues/1434
+    return hostkeys[0] if hostkeys.length == 1
+    hostkeys
   end
 end


### PR DESCRIPTION
and a bit better support for fedora, opensuse 13.2

I can not add the support for opensuse-leap-42.1, as the existing bento box is broken on the latest virtualbox versions

This PR contains the tests for https://github.com/dev-sec/chef-ssh-hardening/pull/166, I think it makes sense to review&merge this PR first and then rerun the tests in the https://github.com/dev-sec/chef-ssh-hardening/pull/166