### PR TITLE
Fix check for os.darwin

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -31,7 +31,7 @@ control 'ssh-01' do
     it { should exist }
     it { should be_file }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into os.darwin ? 'wheel' : 'root' }
+    it { should be_grouped_into os.darwin? ? 'wheel' : 'root' }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -57,7 +57,7 @@ control 'sshd-04' do
     it { should exist }
     it { should be_directory }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into os.darwin ? 'wheel' : 'root' }
+    it { should be_grouped_into os.darwin? ? 'wheel' : 'root' }
     it { should be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }
@@ -77,7 +77,7 @@ control 'sshd-05' do
     it { should exist }
     it { should be_file }
     it { should be_owned_by 'root' }
-    it { should be_grouped_into os.darwin ? 'wheel' : 'root' }
+    it { should be_grouped_into os.darwin? ? 'wheel' : 'root' }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should_not be_readable.by('group') }


### PR DESCRIPTION
Fixes bug introduced by #82 

```
×  File /etc/ssh/ssh_config
undefined method `darwin' for Operating System Detection:#<Class:0x007fe3711f3680>
```