### PR TITLE
CI: update to ruby 2.4.1 and rubocop 0.49

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.3
+  - 2.4.1
 
 bundler_args: --without integration
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'highline', '~> 1.6.0'
 gem 'inspec', '~> 1'
 gem 'rack', '1.6.4'
 gem 'rake'
-gem 'rubocop', '~> 0.46.0'
+gem 'rubocop', '~> 0.49.0'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # encoding: utf-8
 
 require 'rake/testtask'

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -204,9 +204,9 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
 
   # return a list of valid algoriths for a current platform
   def valid_algorithms # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
-    alg53 = %w(rsa)
-    alg60 = %w(rsa ecdsa)
-    alg66 = %w(rsa ecdsa ed25519)
+    alg53 = %w[rsa]
+    alg60 = %w[rsa ecdsa]
+    alg66 = %w[rsa ecdsa ed25519]
     alg = alg66 # probably its a best suitable set for everything unknown
 
     case inspec.os[:name]


### PR DESCRIPTION
Chef 13 is also using ruby 2.4.1 in the omnibus packages

Signed-off-by: Artem Sidorenko <artem@posteo.de>