### PR TITLE
control sshd-14 fails on Amazon Linux

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -247,6 +247,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /10.10\./, /10.11\./, /10.12\./
         alg66
       end
+    when 'amazon'
+      alg = alg53
     end
 
     alg


### PR DESCRIPTION
Amazon Linux set the parameter HostKey on the file “/etc/ssh/sshd_config” with the value "/etc/ssh/ssh_host_rsa_key", causing the control sshd-14 to fail.

To get it fixed I added a condition on the code block that set the valid_algorithms on the file ssh_crypto.rb, stating that when inspec.os[:name] returns ’amazon’,  alg = alg53.