### PR TITLE
Check absolute path

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -19,7 +19,7 @@
 title 'SSH server config'
 
 only_if do
-  command('sshd').exist?
+  command('/usr/sbin/sshd').exist?
 end
 
 control 'sshd-01' do


### PR DESCRIPTION
Hi,

Without specifying the path to `sshd` tests are skipped (target OSes are CentOS 6 and 7).  Amending the `only_if` block fixed the tests in my environment.

Using inspec 1.41.0.