### PR TITLE
Modified the client_alive_interval default to suggested value

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -354,7 +354,7 @@ control 'sshd-36' do
   title 'Server: Set a client alive interval'
   desc 'ClientAlive messages are sent over encrypted connection and are not spoofable.'
   describe sshd_config do
-    its('ClientAliveInterval') { should eq('600') }
+    its('ClientAliveInterval') { should eq('300') }
   end
 end
 


### PR DESCRIPTION
While this cookbook isn't specific (and shouldn't be specific) to CIS Benchmarks, it's helpful as a
baseline to set the default behaviors to the recommended value. Folks can override to 600 if needed
in chef-ssh-hardening cookbook.
