### PR TITLE
Fix bogus success of sshd-47 on non Debian

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -458,7 +458,7 @@ control 'sshd-47' do
       its('DebianBanner') { should eq('no') }
     end
   else
-    describe file(sshd_config.path) do
+    describe sshd_config do
       its('content') { should_not match(/DebianBanner/) }
     end
   end


### PR DESCRIPTION
since sshd_config dose not have the path method, sshd-47 reports the false-negative on non Debian platform.