### PR TITLE
possible fix for #95 deprecated option UseLogin

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -174,7 +174,7 @@ control 'sshd-15' do
   title 'Server: Specify UseLogin to NO'
   desc 'Disable legacy login mechanism and do not use login for interactive login sessions.'
   describe sshd_config do
-    its('UseLogin') { should eq('no') }
+    its('UseLogin') { should_not eq('yes') }
   end
 end
 


### PR DESCRIPTION
In my testing this fixes the deprecation of the UseLogin option in more recent OpenSSH versions.
Additionally, it should detect the insecure configuration as far back as OpenSSH 3.0.2 (release notes link below state that UseLogin was NOT ENABLED by default at that time)

https://www.openssh.com/txt/release-3.0.2