### PR TITLE
Avoid failing on EL 6 family and OpenSuse Leap 42

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -468,7 +468,7 @@ control 'sshd-48' do
   impact 1.0
   title 'Server: DH primes'
   desc 'Verifies if strong DH primes are used in /etc/ssh/moduli'
-  describe command("test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }' /etc/ssh/moduli | uniq | wc -c) -eq 0") do
+  describe bash("test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }' /etc/ssh/moduli | uniq | wc -c) -eq 0") do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq '' }
     its('stderr') { should eq '' }


### PR DESCRIPTION
With command it fails for whatever reason, with bash resource
it works just fine:

```bash
  ×  sshd-48: Server: DH primes (1 failed)
     ✔  Command: `test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }'
/etc/ssh/moduli | uniq | wc -c) -eq 0` exit_status should eq 0
     ✔  Command: `test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }'
/etc/ssh/moduli | uniq | wc -c) -eq 0` stdout should eq ""
     ×  Command: `test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }'
/etc/ssh/moduli | uniq | wc -c) -eq 0` stderr should eq ""

     expected: ""
          got: "awk: cmd. line:1: fatal: cannot open file
`/etc/ssh/moduli' for reading (Permission denied)\n"

     (compared using ==)

     Diff:
     @@ -1 +1,2 @@
     +awk: cmd. line:1: fatal: cannot open file `/etc/ssh/moduli' for
reading (Permission denied)
```

Signed-off-by: Artem Sidorenko <artem@posteo.de>