### PR TITLE
Fixup of UsePrivilegeSeparation deprecation for Amazon

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -207,7 +207,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /18\./
         ps = ps75
       end
-    when 'amazon', 'fedora', 'alpine'
+    when 'fedora', 'alpine'
       ps = ps75
     end
 


### PR DESCRIPTION
Amazon Linux still has it with OpenSSH 7.4

Signed-off-by: Artem Sidorenko <artem@posteo.de>