### PR TITLE
Fix OS-version detection

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -40,9 +40,9 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'debian'
       case inspec.os[:release]
-      when /6\./, /7\./
+      when /^6\./, /^7\./
         ciphers = ciphers53
-      when /8\./, /9\./
+      when /^8\./, /^9\./
         ciphers = ciphers66
       end
     when 'redhat', 'centos', 'oracle'


### PR DESCRIPTION
Before this commit the regex searched for the pattern anywhere in the string. This resulted in the following on Centos 7.6:

(The `string centos release:` was added as a debug output)
```
basti$ bundle exec inspec exec ../ssh-baseline/ -t docker://79335b76fbaf --controls=ssh-08
"centos release: 7.6.1810"
"centos release: 7.6.1810"

Profile: DevSec SSH Baseline (ssh-baseline)
Version: 2.3.2
Target:  docker://79335b76fbaf7cf6877bd4b86f220cde2dba595baeb96ec6feb5ede279c17bc1

  ×  ssh-08: Client: Check for secure ssh ciphers
     ×  SSH Configuration Ciphers should eq "aes256-ctr,aes192-ctr,aes128-ctr"

     expected: "aes256-ctr,aes192-ctr,aes128-ctr"
          got: "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr"

     (compared using ==)

Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 1 failure, 0 skipped
```
For the version string `7.6.1810` the case-statement in the library found `6\.` and since this is the first case statement, ciphers will get set to ciphers53.

This commit changes the behaviour to look for the pattern at the beginning of the line.

Open question:
Are all version-strings just the number without anything before or after it? I could not check for MacOS,
so I changed the regex only for the OS I knew.