### PR TITLE
UseRoaming is deprecated, only check on older versions

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -219,6 +219,7 @@ control 'ssh-21' do
   impact 1.0
   title 'Client: Do not allow Roaming'
   desc 'Workaround for SSH Client Bug CVE-2016-0777 and CVE-2016-0778'
+  only_if { ssh_crypto.ssh_version < 7.2 }
   describe ssh_config do
     its('UseRoaming') { should eq('no') }
   end


### PR DESCRIPTION
UseRoaming was deprecated in OpenSSH 7.2, see this commit:

https://github.com/openssh/openssh-portable/commit/a306863831c57ec5fad918687cc5d289ee8e2635

This PR adds a condition so the control checks only on
older version.

Fixes #121