### PR TITLE
Bump version to 2.4.1 and switch to inspec 3 for check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@
 AllCops:
   Exclude:
   - vendor/**/*
-  - "*/puppet/Puppetfile"
-  - "*/puppet/.tmp/**/*"
-  TargetRubyVersion: 1.9
 Documentation:
   Enabled: false
 AlignParameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 **Merged pull requests:**
 
+- 2.4.0 [\#124](https://github.com/dev-sec/ssh-baseline/pull/124) ([chris-rock](https://github.com/chris-rock))
 - Allow prohibit-password as PermitRootLogin value [\#123](https://github.com/dev-sec/ssh-baseline/pull/123) ([jeremy-clerc](https://github.com/jeremy-clerc))
 - UseRoaming is deprecated, only check on older versions [\#122](https://github.com/dev-sec/ssh-baseline/pull/122) ([rndmh3ro](https://github.com/rndmh3ro))
 - Fix os detection [\#120](https://github.com/dev-sec/ssh-baseline/pull/120) ([IceBear2k](https://github.com/IceBear2k))

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '~> 1'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.49.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-# encoding: utf-8
+#!/usr/bin/env rake
 
 require 'rake/testtask'
 require 'rubocop/rake_task'
@@ -19,23 +19,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'ssh-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice SSH hardening
-version: 2.4.0
+version: 2.4.1
 supports:
   - os-family: unix

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -271,6 +271,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     # we have to return a string if we have a single-element
     # https://github.com/chef/inspec/issues/1434
     return hostkeys[0] if hostkeys.length == 1
+
     hostkeys
   end
 end


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:
```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```