### PR TITLE
Debian 10 has Openssh 7.9 with deperecated UsePrivilegeSeparation

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -193,6 +193,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       case inspec.os[:release]
       when /^6\./
         ps = ps53
+      when /^10\./
+        ps = ps75
       end
     when 'redhat', 'centos', 'oracle'
       case inspec.os[:release]


### PR DESCRIPTION
https://www.openssh.com/txt/release-7.5

Signed-off-by: Artem Sidorenko <artem@posteo.de>