### PR TITLE
Issue 137 - MaxAuthTries Parameter.

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -218,9 +218,11 @@ end
 control 'sshd-19' do
   impact 1.0
   title 'Server: Specify Limit for maximum authentication retries'
-  desc 'MaxAuthTries limits the user to three wrong attempts before the login attempt is denied. This avoid resource starvation attacks.'
+  desc 'The MaxAuthTries parameter specifies the maximum number of authentication attempts permitted per connection. When the login failure count reaches half the number, error messages will be written to the syslog file detailing the login failure. Setting the MaxAuthTries parameter to a low number will minimize the risk of successful brute force attacks to the SSH server. The default is 2 but should be configured based on site policy.'
+  tag 'CIS Red Hat Enterprise Linux 7 Benchmark version 01-31-2017': '2.1.1'
+  ref 'Center for Internet Security', url: 'https://www.cisecurity.org/'
   describe sshd_config do
-    its('MaxAuthTries') { should eq('2') }
+    its('MaxAuthTries') { should be == attribute('max_auth_tries') }
   end
 end
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -8,3 +8,9 @@ summary: Test-suite for best-practice SSH hardening
 version: 2.4.1
 supports:
   - os-family: unix
+attributes:
+  - name: max_auth_tries
+    required: false
+    description: 'define MaxAuthTries'
+    value: 2
+    type: numeric


### PR DESCRIPTION
Add reference and more detailed description of this configuration option
(taken from CIS benchmark document).

Allow ability to override the default of 2, in some instances this can be too
aggressive causing lockouts to users with multiple keys loaded in the ssh agent.