### PR TITLE
Move atribute to spec as local var

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -223,7 +223,7 @@ control 'sshd-19' do
   tag 'CIS Red Hat Enterprise Linux 7 Benchmark version 01-31-2017': '2.1.1'
   ref 'Center for Internet Security', url: 'https://www.cisecurity.org/'
   describe sshd_config do
-    its('MaxAuthTries') { should cmp == attribute('sshd_max_auth_tries') }
+    its('MaxAuthTries') { should cmp(sshd_max_auth_tries) }
   end
 end
 

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -18,15 +18,16 @@
 
 title 'SSH server config'
 
-sshd_valid_ciphers = attribute('sshd_valid_ciphers', default: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
-sshd_valid_kexs = attribute('sshd_valid_kexs', default: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
-sshd_valid_macs = attribute('sshd_valid_macs', default: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
-sshd_permittunnel = attribute('sshd_permittunnel', default: 'no', description: 'Expected value for sshd_config PermitTunnel')
-sshd_tcpforwarding = attribute('sshd_tcpforwarding', default: 'no', description: 'Expected value for sshd_config TcpForwarding')
-sshd_agentforwarding = attribute('sshd_agentforwarding', default: 'no', description: 'Expected value for sshd_config AgentForwarding')
-sshd_gatewayports = attribute('sshd_gatewayports', default: 'no', description: 'Expected value for sshd_config GatewayPorts')
-sshd_x11forwarding = attribute('sshd_x11forwarding', default: 'no', description: 'Expected value for sshd_config X11Forwarding')
-sshd_banner = attribute('sshd_banner', default: 'none', description: 'Expected value for sshd_config Banner')
+sshd_valid_ciphers = attribute('sshd_valid_ciphers', value: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
+sshd_valid_kexs = attribute('sshd_valid_kexs', value: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
+sshd_valid_macs = attribute('sshd_valid_macs', value: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
+sshd_permittunnel = attribute('sshd_permittunnel', value: 'no', description: 'Expected value for sshd_config PermitTunnel')
+sshd_tcpforwarding = attribute('sshd_tcpforwarding', value: 'no', description: 'Expected value for sshd_config TcpForwarding')
+sshd_agentforwarding = attribute('sshd_agentforwarding', value: 'no', description: 'Expected value for sshd_config AgentForwarding')
+sshd_gatewayports = attribute('sshd_gatewayports', value: 'no', description: 'Expected value for sshd_config GatewayPorts')
+sshd_x11forwarding = attribute('sshd_x11forwarding', value: 'no', description: 'Expected value for sshd_config X11Forwarding')
+sshd_banner = attribute('sshd_banner', value: 'none', description: 'Expected value for sshd_config Banner')
+sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'Expected value for max_auth_retries')
 
 only_if do
   command('sshd').exist?
@@ -222,7 +223,7 @@ control 'sshd-19' do
   tag 'CIS Red Hat Enterprise Linux 7 Benchmark version 01-31-2017': '2.1.1'
   ref 'Center for Internet Security', url: 'https://www.cisecurity.org/'
   describe sshd_config do
-    its('MaxAuthTries') { should cmp == attribute('max_auth_tries') }
+    its('MaxAuthTries') { should cmp == attribute('sshd_max_auth_tries') }
   end
 end
 

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -18,15 +18,15 @@
 
 title 'SSH server config'
 
-sshd_valid_ciphers = attribute('sshd_valid_ciphers', value: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
-sshd_valid_kexs = attribute('sshd_valid_kexs', value: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
-sshd_valid_macs = attribute('sshd_valid_macs', value: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
-sshd_permittunnel = attribute('sshd_permittunnel', value: 'no', description: 'Expected value for sshd_config PermitTunnel')
-sshd_tcpforwarding = attribute('sshd_tcpforwarding', value: 'no', description: 'Expected value for sshd_config TcpForwarding')
-sshd_agentforwarding = attribute('sshd_agentforwarding', value: 'no', description: 'Expected value for sshd_config AgentForwarding')
-sshd_gatewayports = attribute('sshd_gatewayports', value: 'no', description: 'Expected value for sshd_config GatewayPorts')
-sshd_x11forwarding = attribute('sshd_x11forwarding', value: 'no', description: 'Expected value for sshd_config X11Forwarding')
-sshd_banner = attribute('sshd_banner', value: 'none', description: 'Expected value for sshd_config Banner')
+sshd_valid_ciphers = attribute('sshd_valid_ciphers', default: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
+sshd_valid_kexs = attribute('sshd_valid_kexs', default: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
+sshd_valid_macs = attribute('sshd_valid_macs', default: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
+sshd_permittunnel = attribute('sshd_permittunnel', default: 'no', description: 'Expected value for sshd_config PermitTunnel')
+sshd_tcpforwarding = attribute('sshd_tcpforwarding', default: 'no', description: 'Expected value for sshd_config TcpForwarding')
+sshd_agentforwarding = attribute('sshd_agentforwarding', default: 'no', description: 'Expected value for sshd_config AgentForwarding')
+sshd_gatewayports = attribute('sshd_gatewayports', default: 'no', description: 'Expected value for sshd_config GatewayPorts')
+sshd_x11forwarding = attribute('sshd_x11forwarding', default: 'no', description: 'Expected value for sshd_config X11Forwarding')
+sshd_banner = attribute('sshd_banner', default: 'none', description: 'Expected value for sshd_config Banner')
 sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'Expected value for max_auth_retries')
 
 only_if do

--- a/inspec.yml
+++ b/inspec.yml
@@ -8,9 +8,3 @@ summary: Test-suite for best-practice SSH hardening
 version: 2.4.1
 supports:
   - os-family: unix
-attributes:
-  - name: max_auth_tries
-    required: false
-    description: 'define MaxAuthTries'
-    value: 2
-    type: numeric


### PR DESCRIPTION
This solves an unwanted sideeffect of #138 where passing an attributes.yml to inspec that doesn't contain max_auth_tries it breaks the test. This change solves that, you can now still override the attribute if you need more or less tries but you can now pass attributes again without explicitly repeating the default value (2). Also refactors to a more clear attribute name.