### PR TITLE
Use SHA2 HMACs in OpenSSH for RHEL family 6.5+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,4 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 30
+  Max: 33

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,4 +23,4 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Max: 10
 Metrics/AbcSize:
-  Max: 33
+  Max: 31

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -130,6 +130,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     macs66 = 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256'
     macs59 = 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'
     macs53 = 'hmac-ripemd160,hmac-sha1'
+    macs53_el65 = 'hmac-sha2-512,hmac-sha2-256'
     macs = macs59
 
     # adjust MACs based on OS + release
@@ -152,8 +153,12 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'redhat', 'centos', 'oracle'
       case inspec.os[:release]
-      when /^6\./
-        macs = macs53
+      when /^6\.(\d+)/
+        macs = if Regexp.last_match(1).to_i >= 5
+                 macs53_el65
+               else
+                 macs53
+               end
       when /^7\./, /^8\./
         macs = macs66
       end

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -153,12 +153,8 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     when 'redhat', 'centos', 'oracle'
       case inspec.os[:release]
-      when /^6\.(\d+)/
-        macs = if Regexp.last_match(1).to_i >= 5
-                 macs53_el65
-               else
-                 macs53
-               end
+      when /^6\./
+        macs = macs53_el65
       when /^7\./, /^8\./
         macs = macs66
       end

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -154,6 +154,11 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     when 'redhat', 'centos', 'oracle'
       case inspec.os[:release]
       when /^6\./
+        # RedHat Enterprise Linux (and family) backported SHA2 support to their fork of OpenSSH 5.3 in RHEL 6.5.
+        # See BZ#969565 at:
+        # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html-single/6.5_technical_notes/index#openssh
+        # Because extended support (EUS) updates for 6.x minor releases is no longer available,
+        # only the settings available for the supported (latest) 6.x release are recommended.
         macs = macs53_el65
       when /^7\./, /^8\./
         macs = macs66


### PR DESCRIPTION
Closes #145 

I have not tested these HMACs Oracle Linux 6.5, however according to their documentation there is no package change for OpenSSH from their upstream.