### PR TITLE
In a container, sshd should not run as root

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -22,16 +22,28 @@ only_if do
   command('ssh').exist?
 end
 
+custom_user = attribute(
+  'custom_user',
+  value: 'root',
+  description: 'The SSH user is not always root. It must be an unprivileged user in a container'
+)
+
+custom_path = attribute(
+  'custom_path',
+  value: '/etc/ssh',
+  description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag'
+)
+
 control 'ssh-01' do
   impact 1.0
   title 'client: Check ssh_config owner, group and permissions.'
-  desc 'The ssh_config should owned by root, only be writable by owner and readable to all.'
+  desc 'The ssh_config should owned by root or a specified user, only be writable by owner and readable to all.'
 
-  describe file('/etc/ssh/ssh_config') do
+  describe file(custom_path + '/ssh_config') do
     it { should exist }
     it { should be_file }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into os.darwin? ? 'wheel' : 'root' }
+    it { should be_owned_by custom_user }
+    it { should be_grouped_into os.darwin? ? 'wheel' : custom_user }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }

--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -22,28 +22,19 @@ only_if do
   command('ssh').exist?
 end
 
-custom_user = attribute(
-  'custom_user',
-  value: 'root',
-  description: 'The SSH user is not always root. It must be an unprivileged user in a container'
-)
-
-custom_path = attribute(
-  'custom_path',
-  value: '/etc/ssh',
-  description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag'
-)
+ssh_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
+ssh_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
 control 'ssh-01' do
   impact 1.0
   title 'client: Check ssh_config owner, group and permissions.'
   desc 'The ssh_config should owned by root or a specified user, only be writable by owner and readable to all.'
 
-  describe file(custom_path + '/ssh_config') do
+  describe file(ssh_custom_path + '/ssh_config') do
     it { should exist }
     it { should be_file }
     it { should be_owned_by custom_user }
-    it { should be_grouped_into os.darwin? ? 'wheel' : custom_user }
+    it { should be_grouped_into os.darwin? ? 'wheel' : ssh_custom_user }
     it { should_not be_executable }
     it { should be_readable.by('owner') }
     it { should be_readable.by('group') }

--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -22,8 +22,8 @@ only_if do
   command('ssh').exist?
 end
 
-ssh_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
-ssh_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
+ssh_custom_user = attribute('ssh_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
+ssh_custom_path = attribute('ssh_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
 control 'ssh-01' do
   impact 1.0
@@ -33,7 +33,7 @@ control 'ssh-01' do
   describe file(ssh_custom_path + '/ssh_config') do
     it { should exist }
     it { should be_file }
-    it { should be_owned_by custom_user }
+    it { should be_owned_by ssh_custom_user }
     it { should be_grouped_into os.darwin? ? 'wheel' : ssh_custom_user }
     it { should_not be_executable }
     it { should be_readable.by('owner') }

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -483,7 +483,7 @@ control 'sshd-48' do
   impact 1.0
   title 'Server: DH primes'
   desc 'Verifies if strong DH primes are used in /etc/ssh/moduli'
-  describe bash("test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }' " + sshd_custom_path + "/moduli | uniq | wc -c) -eq 0") do
+  describe bash("test $(awk '$5 < 2047 && $5 ~ /^[0-9]+$/ { print $5 }' #{sshd_custom_path}/moduli | uniq | wc -c) -eq 0") do
     its('exit_status') { should eq 0 }
     its('stdout') { should eq '' }
     its('stderr') { should eq '' }

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -28,8 +28,8 @@ sshd_gatewayports = attribute('sshd_gatewayports', value: 'no', description: 'Ex
 sshd_x11forwarding = attribute('sshd_x11forwarding', value: 'no', description: 'Expected value for sshd_config X11Forwarding')
 sshd_banner = attribute('sshd_banner', value: 'none', description: 'Expected value for sshd_config Banner')
 sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'Expected value for max_auth_retries')
-sshd_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
-sshd_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
+sshd_custom_user = attribute('sshd_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
+sshd_custom_path = attribute('sshd_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
 sshd_valid_privseparation = if sshd_custom_user != 'root'
                               'no'

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -31,7 +31,11 @@ sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'E
 sshd_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
 sshd_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
-sshd_custom_user != 'root' ? sshd_valid_privseparation = 'no' : sshd_valid_privseparation = ssh_crypto.valid_privseparation
+sshd_valid_privseparation = if sshd_custom_user != 'root'
+                              'no'
+                            else
+                              ssh_crypto.valid_privseparation
+                            end
 
 only_if do
   command('sshd').exist?

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -31,6 +31,12 @@ sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'E
 sshd_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
 sshd_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
+sshd_valid_privseparation = ssh_crypto.valid_privseparation
+
+unless sshd_custom_user == 'root' do
+  sshd_valid_privseparation = 'no'
+end
+
 only_if do
   command('sshd').exist?
 end
@@ -196,7 +202,7 @@ control 'sshd-16' do
   title 'Server: Use privilege separation'
   desc 'UsePrivilegeSeparation is an option, when enabled will allow the OpenSSH server to run a small (necessary) amount of code as root and the of the code in a chroot jail environment. This enables ssh to deal incoming network traffic in an unprivileged child process to avoid privilege escalation by an attacker.'
   describe sshd_config do
-    its('UsePrivilegeSeparation') { should eq(ssh_crypto.valid_privseparation) }
+    its('UsePrivilegeSeparation') { should eq(sshd_valid_privseparation) }
   end
 end
 

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -31,11 +31,7 @@ sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'E
 sshd_custom_user = attribute('custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
 sshd_custom_path = attribute('custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
-sshd_valid_privseparation = ssh_crypto.valid_privseparation
-
-unless sshd_custom_user == 'root' do
-  sshd_valid_privseparation = 'no'
-end
+sshd_custom_user != 'root' ? sshd_valid_privseparation = 'no' : sshd_valid_privseparation = ssh_crypto.valid_privseparation
 
 only_if do
   command('sshd').exist?


### PR DESCRIPTION
Add the option to choose the owner of configurations files and their locations.