### PR TITLE
feat(kex): introduce kex for 8.0+, used for alpine and fedora 30+

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -70,6 +70,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
 
   def valid_kexs # rubocop:disable Metrics/CyclomaticComplexity
     # define a set of default KEXs
+    kex80 = 'sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex66 = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex59 = 'diffie-hellman-group-exchange-sha256'
     kex = kex59
@@ -94,8 +95,12 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       when /^7\./, /^8\./
         kex = kex66
       end
-    when 'amazon', 'fedora', 'alpine'
+    when 'amazon'
       kex = kex66
+    when 'alpine'
+      kex = kex80
+    when 'fedora'
+      inspec.os[:release] >= '30' ? kex=kex80 : kex=kex66
     when 'opensuse'
       case inspec.os[:release]
       when /^13\.2/

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -100,7 +100,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     when 'alpine'
       kex = kex80
     when 'fedora'
-      inspec.os[:release] >= '30' ? kex=kex80 : kex=kex66
+      kex = inspec.os[:release] >= '30' ? kex80 : kex66
     when 'opensuse'
       case inspec.os[:release]
       when /^13\.2/


### PR DESCRIPTION
This PR is a second part of dev-sec/ansible-ssh-hardening#281
It also addresses #144 somewhat

From Fedora 30 ( the one which is currently used in `rndmh3ro/docker-fedora-ansible:latest` image for testing ) OpenSSH 8.0p1 is installed. And with changes in dev-sec/ansible-ssh-hardening#254 a separate list of kex was introduced for 8.0 and above in ansible role.

So this PR modifies the test to check for correct list of kex for Fedora with version 30 and higher. I've also took the liberty to set the `kex80` for alpine, although currently not used in testing `docker-alpine-ansible` image will fall into same OpenSSH 8.0+ category.

**This potentially will break other tests** 
It seems `chef-ssh-hardening` repo does set `kex66` list for both Fedora 29 and 30
don't know if there are other places to watch out for
What is the best way forward for this one ?

