### PR TITLE
ListenAddress should exist

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -140,7 +140,7 @@ control 'sshd-09' do
   desc "Limit the SSH server to listen to a specific address. Don't let it listen on all interfaces to avoid logins from unexpected sources."
   describe sshd_config(sshd_custom_path + '/sshd_config') do
     its('ListenAddress') { should_not eq nil }
-    its('ListenAddress') { should_not match /^\s*$/ }
+    its('ListenAddress') { should_not match(/^\s*$/) }
     its('ListenAddress') { should_not eq [] }
   end
 end

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -139,7 +139,7 @@ control 'sshd-09' do
   title 'Server: Specify ListenAddress'
   desc "Limit the SSH server to listen to a specific address. Don't let it listen on all interfaces to avoid logins from unexpected sources."
   describe sshd_config(sshd_custom_path + '/sshd_config') do
-    its('ListenAddress') { should exist }
+    its('ListenAddress') { should_not eq nil }
   end
 end
 

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -139,7 +139,7 @@ control 'sshd-09' do
   title 'Server: Specify ListenAddress'
   desc "Limit the SSH server to listen to a specific address. Don't let it listen on all interfaces to avoid logins from unexpected sources."
   describe sshd_config(sshd_custom_path + '/sshd_config') do
-    its('ListenAddress') { should match(/.*/) }
+    its('ListenAddress') { should exist }
   end
 end
 

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -140,6 +140,8 @@ control 'sshd-09' do
   desc "Limit the SSH server to listen to a specific address. Don't let it listen on all interfaces to avoid logins from unexpected sources."
   describe sshd_config(sshd_custom_path + '/sshd_config') do
     its('ListenAddress') { should_not eq nil }
+    its('ListenAddress') { should_not match /^\s*$/ }
+    its('ListenAddress') { should_not eq [] }
   end
 end
 


### PR DESCRIPTION
There can be multiple ListenAddress (for instance ipv6 and ipv4 failover).

Does the `exist` matcher work for sshd_config ?