### PR TITLE
ssh host keys in a specific directory

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -31,6 +31,7 @@ sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'E
 sshd_custom_user = attribute('sshd_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
 sshd_custom_path = attribute('sshd_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 sshd_custom_port = attribute('sshd_custom_port', value: '22', description: 'Sometimes the ssh port is not 22. For instance, in a container as another user, 22 is forbidden')
+sshd_custom_hostkeys_path = attribute('sshd_custom_hostkeys_path', value: '/etc/ssh', description: 'Sometimes ssh host keys must be in a particular path, in a clustered environment for instance')
 
 sshd_valid_privseparation = if sshd_custom_user != 'root'
                               'no'
@@ -187,7 +188,7 @@ control 'sshd-14' do
   title 'Server: Specify SSH HostKeys'
   desc 'Specify HostKey for protection against Man-In-The-Middle Attacks'
 
-  sshd_valid_hostkeys = ssh_crypto.valid_algorithms.map { |alg| "#{sshd_custom_path}/ssh_host_#{alg}_key" }
+  sshd_valid_hostkeys = ssh_crypto.valid_algorithms.map { |alg| "#{sshd_custom_hostkeys_path}/ssh_host_#{alg}_key" }
   sshd_valid_hostkeys = sshd_valid_hostkeys[0] if sshd_valid_hostkeys.length == 1
 
   describe sshd_config(sshd_custom_path + '/sshd_config') do


### PR DESCRIPTION
Sometimes, ssh host keys must be in a different path. In a mountpoint in a clustered environment for instance.