### PR TITLE
add control for CRYPTO_POLICY on RedHat

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -503,3 +503,17 @@ control 'sshd-48' do
     its('stderr') { should eq '' }
   end
 end
+
+control 'sshd-49' do
+  impact 1.0
+  title 'Server: CRYPTO_POLICY'
+  desc 'Verifies, that we are not running CRYPTO_POLICY and our settings from sshd_config are effective'
+  if os[:family] == "redhat" && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
+    describe bash("pgrep -af 'sshd -D'") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should_not match('-oCiphers') }
+      its('stdout') { should_not match('-oKexAlgorithms') }
+      its('stdout') { should_not match('-oHostKeyAlgorithms') }
+    end
+  end
+end

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -508,7 +508,7 @@ control 'sshd-49' do
   impact 1.0
   title 'Server: CRYPTO_POLICY'
   desc 'Verifies, that we are not running CRYPTO_POLICY and our settings from sshd_config are effective'
-  if os[:family] == "redhat" && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
+  if os[:family] == 'redhat' && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
     describe bash("pgrep -af 'sshd -D'") do
       its('exit_status') { should eq 0 }
       its('stdout') { should_not match('-oCiphers') }

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -508,12 +508,14 @@ control 'sshd-49' do
   impact 1.0
   title 'Server: CRYPTO_POLICY'
   desc 'Verifies, that we are not running CRYPTO_POLICY and our settings from sshd_config are effective'
-  if os[:family] == 'redhat' && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
-    describe bash("pgrep -af 'sshd -D'") do
-      its('exit_status') { should eq 0 }
-      its('stdout') { should_not match('-oCiphers') }
-      its('stdout') { should_not match('-oKexAlgorithms') }
-      its('stdout') { should_not match('-oHostKeyAlgorithms') }
-    end
+  only_if('OS is RHEL 8+ or compatible') do
+    os[:family] == 'redhat' && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
+  end
+
+  describe bash("pgrep -af 'sshd -D'") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not match('-oCiphers') }
+    its('stdout') { should_not match('-oKexAlgorithms') }
+    its('stdout') { should_not match('-oHostKeyAlgorithms') }
   end
 end


### PR DESCRIPTION
RedHat introduces a CRYPTO_POLICY in RHEL8. This needs to be configured
separately, or it will override sshd_config settings for Cipher, MAC and
Kex.

see: https://access.redhat.com/solutions/4410591