### PR TITLE
rework CRYPTO_POLICY check to work with fedora

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -236,7 +236,7 @@ control 'ssh-22' do
     file('/etc/sysconfig/sshd').exist? && file('/etc/sysconfig/sshd').content.match?(/CRYPTO_POLICY/)
   end
 
-  describe bash("ssh -G localhost") do
+  describe bash('ssh -G localhost') do
     its('exit_status') { should eq 0 }
     its('stdout') { should match('ciphers ' + ssh_crypto.valid_ciphers) }
     its('stdout') { should match('kexalgorithms ' + ssh_crypto.valid_kexs) }

--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -227,3 +227,19 @@ control 'ssh-21' do
     its('UseRoaming') { should eq('no') }
   end
 end
+
+control 'ssh-22' do
+  impact 1.0
+  title 'Client: CRYPTO_POLICY'
+  desc 'Verifies, that we are not running CRYPTO_POLICY and our settings from ssh_config are effective'
+  only_if('OS has CRYPTO_POLICY') do
+    file('/etc/sysconfig/sshd').exist? && file('/etc/sysconfig/sshd').content.match?(/CRYPTO_POLICY/)
+  end
+
+  describe bash("ssh -G localhost") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match('ciphers ' + ssh_crypto.valid_ciphers) }
+    its('stdout') { should match('kexalgorithms ' + ssh_crypto.valid_kexs) }
+    its('stdout') { should match('macs ' + ssh_crypto.valid_macs) }
+  end
+end

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -508,8 +508,8 @@ control 'sshd-49' do
   impact 1.0
   title 'Server: CRYPTO_POLICY'
   desc 'Verifies, that we are not running CRYPTO_POLICY and our settings from sshd_config are effective'
-  only_if('OS is RHEL 8+ or compatible') do
-    os[:family] == 'redhat' && ::Gem::Version.new(os.release) > ::Gem::Version.new('8')
+  only_if('OS has CRYPTO_POLICY') do
+    file('/etc/sysconfig/sshd').exist? && file('/etc/sysconfig/sshd').content.match?(/CRYPTO_POLICY/)
   end
 
   describe bash("pgrep -af 'sshd -D'") do


### PR DESCRIPTION
since fedora uses different version scheme it was not covered by previous
check. Also add checks for ssh client, to see if we successfully
override CRYPTO_POLICY there

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>