### PR TITLE
Legacy Protocol statement is removed from version 7.6 and above, sinc…

### DIFF
--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -151,6 +151,7 @@ control 'sshd-10' do
   impact 1.0
   title 'Server: Specify protocol version 2'
   desc "Only SSH protocol version 2 connections should be permitted. Version 1 of the protocol contains security vulnerabilities. Don't use legacy insecure SSHv1 connections anymore."
+  only_if { ssh_crypto.ssh_version < 7.6 }
   describe sshd_config(sshd_custom_path + '/sshd_config') do
     its('Protocol') { should eq('2') }
   end


### PR DESCRIPTION
…e the code for SSH-1 is removed from sshd.

See: https://github.com/dev-sec/ansible-collection-hardening/pull/342

The code for SSH version 1 was removed from OpenSSHd. The later versions without SSH-1 don't have the Protocol statement in the manual pages.

This is my first time changing code for the baseline. Please double check my if-statement ;-)

Signed-off-by: Farid Joubbi <farid@joubbi.se>