### PR TITLE
Legacy Protocol statement is removed from version 7.6 and above, sinc…

### DIFF
--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -67,6 +67,7 @@ control 'ssh-04' do
   impact 1.0
   title 'Client: Specify protocol version 2'
   desc "Only SSH protocol version 2 connections should be permitted. Version 1 of the protocol contains security vulnerabilities. Don't use legacy insecure SSHv1 connections anymore."
+  only_if { ssh_crypto.ssh_version < 7.6 }
   describe ssh_config(ssh_custom_path + '/ssh_config') do
     its('Protocol') { should eq('2') }
   end


### PR DESCRIPTION
…e the code for SSH-1 is removed from OpenSSH.

See #184 The same change was made for sshd_config. This one is for ssh_config.

Signed-off-by: Farid Joubbi <farid@joubbi.se>