### PR TITLE
Added OpenSSH 8.5/8.5p1 KexAlgorithms Support

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -105,25 +105,18 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
         kex = kex80
       end
     # https://pkgs.alpinelinux.org/packages?name=openssh
-    when 'arch'
-      kex = ssh_version >= 8.5 ? kex85 : kex80
-    when 'alpine'
-      kex = inspec.os[:release].split('.')[1] >= '10' ? kex80 : kex66
+    # https://src.fedoraproject.org/rpms/openssh
+    # https://software.opensuse.org/package/openssh
+    when 'alpine', 'arch', 'fedora', 'opensuse'
+      kex = if ssh_version >= 8.5
+        kex85
+      elsif ssh_version >= 8.0
+        kex80
+      elsif ssh_version >= 6.6
+        kex66
+      end
     when 'amazon'
       kex = kex66
-    # https://src.fedoraproject.org/rpms/openssh
-    when 'fedora'
-      release = inspec.os[:release]
-      kex = if release >= '35'
-              kex85
-            elsif release >= '30'
-              kex80
-            else
-              kex66
-            end
-    # https://software.opensuse.org/package/openssh
-    when 'opensuse'
-      kex = inspec.os[:release] >= '15.2' ? kex80 : kex66
     when 'mac_os_x'
       case inspec.os[:release]
       when /^10.9\./

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -113,10 +113,10 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       kex = kex66
     # https://src.fedoraproject.org/rpms/openssh
     when 'fedora'
-      release = inspec.os[:release].to_i
-      kex = if release >= 35
+      release = inspec.os[:release]
+      kex = if release >= '35'
               kex85
-            elsif release >= 30
+            elsif release >= '30'
               kex80
             else
               kex66

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -109,12 +109,12 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     # https://software.opensuse.org/package/openssh
     when 'alpine', 'arch', 'fedora', 'opensuse'
       kex = if ssh_version >= 8.5
-        kex85
-      elsif ssh_version >= 8.0
-        kex80
-      elsif ssh_version >= 6.6
-        kex66
-      end
+              kex85
+            elsif ssh_version >= 8.0
+              kex80
+            elsif ssh_version >= 6.6
+              kex66
+            end
     when 'amazon'
       kex = kex66
     when 'mac_os_x'

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -114,10 +114,9 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     # https://src.fedoraproject.org/rpms/openssh
     when 'fedora'
       release = inspec.os[:release].to_i
-      case
-      when release >= 35
+      if release >= 35
         kex = kex85
-      when release >= 30
+      elsif release >= 30
         kex = kex80
       else
         kex = kex66

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -113,7 +113,15 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       kex = kex66
     # https://src.fedoraproject.org/rpms/openssh
     when 'fedora'
-      kex = inspec.os[:release] >= '30' ? kex80 : kex66
+      release = inspec.os[:release].to_i
+      case
+      when release >= 35
+        kex = kex85
+      when release >= 30
+        kex = kex80
+      else
+        kex = kex66
+      end
     # https://software.opensuse.org/package/openssh
     when 'opensuse'
       kex = inspec.os[:release] >= '15.2' ? kex80 : kex66

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -72,6 +72,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
 
   def valid_kexs # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
     # define a set of default KEXs
+    kex85 = 'sntrup761x25519-sha512@openssh.com,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex80 = 'sntrup4591761x25519-sha512@tinyssh.org,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex66 = 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'
     kex59 = 'diffie-hellman-group-exchange-sha256'
@@ -105,7 +106,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     # https://pkgs.alpinelinux.org/packages?name=openssh
     when 'arch'
-      kex = kex80
+      kex = kex85
     when 'alpine'
       kex = inspec.os[:release].split('.')[1] >= '10' ? kex80 : kex66
     when 'amazon'

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -114,13 +114,13 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
     # https://src.fedoraproject.org/rpms/openssh
     when 'fedora'
       release = inspec.os[:release].to_i
-      if release >= 35
-        kex = kex85
-      elsif release >= 30
-        kex = kex80
-      else
-        kex = kex66
-      end
+      kex = if release >= 35
+              kex85
+            elsif release >= 30
+              kex80
+            else
+              kex66
+            end
     # https://software.opensuse.org/package/openssh
     when 'opensuse'
       kex = inspec.os[:release] >= '15.2' ? kex80 : kex66

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -106,7 +106,7 @@ class SshCrypto < Inspec.resource(1) # rubocop:disable Metrics/ClassLength
       end
     # https://pkgs.alpinelinux.org/packages?name=openssh
     when 'arch'
-      kex = kex85
+      kex = ssh_version >= 8.5 ? kex85 : kex80
     when 'alpine'
       kex = inspec.os[:release].split('.')[1] >= '10' ? kex80 : kex66
     when 'amazon'


### PR DESCRIPTION
OpenSSH 8.5 was released on 2021-03-03 and was officially made available for Arch Linux on 2021-03-04 17:09 UTC. The previous key exchange method `sntrup4591761x25519-sha512@tinyssh.org` is replaced with `sntrup761x25519-sha512@openssh.com` in this release. Consequently, the `ssh_crypto.rb` library has to be updated.