### PR TITLE
add dependency to chef-config for CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ end
 
 source 'https://packagecloud.io/cinc-project/stable' do
   gem 'cinc-auditor-bin'
+  gem 'chef-config'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :tools do
 end
 
 source 'https://packagecloud.io/cinc-project/stable' do
-  gem 'cinc-auditor-bin'
   gem 'chef-config'
+  gem 'cinc-auditor-bin'
 end


### PR DESCRIPTION
the gem chef-config ist contained in both repos rubygems.org and
cinc-project. This seems to confuse bundler when installing gems.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>