### PR TITLE
use input instead of attribute

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-#!/usr/bin/env rake
 # frozen_string_literal: true
 
 require 'rake/testtask'
@@ -25,25 +24,4 @@ namespace :test do
     profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
     pp profile.check
   end
-end
-
-task :changelog do
-  # Automatically generate a changelog for this project. Only loaded if
-  # the necessary gem is installed. By default its picking up the version from
-  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts " * Generating changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
-    config.user = 'dev-sec'
-    config.project = 'ssh-baseline'
-  end
-  Rake::Task[:changelog].execute
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
-
 end

--- a/controls/ssh_spec.rb
+++ b/controls/ssh_spec.rb
@@ -24,8 +24,8 @@ only_if do
   command('ssh').exist?
 end
 
-ssh_custom_user = attribute('ssh_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
-ssh_custom_path = attribute('ssh_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
+ssh_custom_user = input('ssh_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
+ssh_custom_path = input('ssh_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
 
 control 'ssh-01' do
   impact 1.0

--- a/controls/sshd_spec.rb
+++ b/controls/sshd_spec.rb
@@ -20,20 +20,20 @@
 
 title 'SSH server config'
 
-sshd_valid_ciphers = attribute('sshd_valid_ciphers', value: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
-sshd_valid_kexs = attribute('sshd_valid_kexs', value: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
-sshd_valid_macs = attribute('sshd_valid_macs', value: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
-sshd_permittunnel = attribute('sshd_permittunnel', value: 'no', description: 'Expected value for sshd_config PermitTunnel')
-sshd_tcpforwarding = attribute('sshd_tcpforwarding', value: 'no', description: 'Expected value for sshd_config TcpForwarding')
-sshd_agentforwarding = attribute('sshd_agentforwarding', value: 'no', description: 'Expected value for sshd_config AgentForwarding')
-sshd_gatewayports = attribute('sshd_gatewayports', value: 'no', description: 'Expected value for sshd_config GatewayPorts')
-sshd_x11forwarding = attribute('sshd_x11forwarding', value: 'no', description: 'Expected value for sshd_config X11Forwarding')
-sshd_banner = attribute('sshd_banner', value: 'none', description: 'Expected value for sshd_config Banner')
-sshd_max_auth_tries = attribute('sshd_max_auth_tries', value: 2, description: 'Expected value for max_auth_retries')
-sshd_custom_user = attribute('sshd_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
-sshd_custom_path = attribute('sshd_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
-sshd_custom_port = attribute('sshd_custom_port', value: '22', description: 'Sometimes the ssh port is not 22. For instance, in a container as another user, 22 is forbidden')
-sshd_custom_hostkeys_path = attribute('sshd_custom_hostkeys_path', value: '/etc/ssh', description: 'Sometimes ssh host keys must be in a particular path, in a clustered environment for instance')
+sshd_valid_ciphers = input('sshd_valid_ciphers', value: ssh_crypto.valid_ciphers, description: 'Expected value for sshd_config ciphers')
+sshd_valid_kexs = input('sshd_valid_kexs', value: ssh_crypto.valid_kexs, description: 'Expected value for sshd_config kexs')
+sshd_valid_macs = input('sshd_valid_macs', value: ssh_crypto.valid_macs, description: 'Expected value for sshd_config macs')
+sshd_permittunnel = input('sshd_permittunnel', value: 'no', description: 'Expected value for sshd_config PermitTunnel')
+sshd_tcpforwarding = input('sshd_tcpforwarding', value: 'no', description: 'Expected value for sshd_config TcpForwarding')
+sshd_agentforwarding = input('sshd_agentforwarding', value: 'no', description: 'Expected value for sshd_config AgentForwarding')
+sshd_gatewayports = input('sshd_gatewayports', value: 'no', description: 'Expected value for sshd_config GatewayPorts')
+sshd_x11forwarding = input('sshd_x11forwarding', value: 'no', description: 'Expected value for sshd_config X11Forwarding')
+sshd_banner = input('sshd_banner', value: 'none', description: 'Expected value for sshd_config Banner')
+sshd_max_auth_tries = input('sshd_max_auth_tries', value: 2, description: 'Expected value for max_auth_retries')
+sshd_custom_user = input('sshd_custom_user', value: 'root', description: 'The SSH user is not always root. It must be an unprivileged user in a container')
+sshd_custom_path = input('sshd_custom_path', value: '/etc/ssh', description: 'Sometimes ssh configuration files are present in another location and ssh use them with the -f flag')
+sshd_custom_port = input('sshd_custom_port', value: '22', description: 'Sometimes the ssh port is not 22. For instance, in a container as another user, 22 is forbidden')
+sshd_custom_hostkeys_path = input('sshd_custom_hostkeys_path', value: '/etc/ssh', description: 'Sometimes ssh host keys must be in a particular path, in a clustered environment for instance')
 
 sshd_valid_privseparation = if sshd_custom_user != 'root'
                               'no'

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,7 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test-suite for best-practice SSH hardening
+inspec_version: '>= 4.6.3'
 version: 2.7.0
 supports:
     - os-family: unix


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/