### PR TITLE
add basic support for Ubuntu 22

### DIFF
--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -82,7 +82,13 @@ class SshCrypto < Inspec.resource(1)
     case inspec.os[:name]
     # https://packages.ubuntu.com/search?keywords=openssh-server
     when 'ubuntu'
-      kex = inspec.os[:release][0, 2] >= '19' ? kex80 : kex66
+      kex = if inspec.os[:release][0, 2] >= '22'
+        kex85
+      elsif inspec.os[:release][0, 2] >= '19'
+        kex80
+      else
+        kex66
+      end
     # https://packages.debian.org/search?keywords=openssh-server
     when 'debian'
       case inspec.os[:release]
@@ -215,7 +221,7 @@ class SshCrypto < Inspec.resource(1)
       end
     when 'ubuntu'
       case inspec.os[:release]
-      when /^18\./, /^20\./
+      when /^18\./, /^20\./, /^22\./
         ps = ps75
       end
     when 'fedora', 'alpine', 'arch'

--- a/libraries/ssh_crypto.rb
+++ b/libraries/ssh_crypto.rb
@@ -83,12 +83,12 @@ class SshCrypto < Inspec.resource(1)
     # https://packages.ubuntu.com/search?keywords=openssh-server
     when 'ubuntu'
       kex = if inspec.os[:release][0, 2] >= '22'
-        kex85
-      elsif inspec.os[:release][0, 2] >= '19'
-        kex80
-      else
-        kex66
-      end
+              kex85
+            elsif inspec.os[:release][0, 2] >= '19'
+              kex80
+            else
+              kex66
+            end
     # https://packages.debian.org/search?keywords=openssh-server
     when 'debian'
       case inspec.os[:release]


### PR DESCRIPTION
This adds basic support for Ubuntu 22. I have not checked if there are newer (better) supported ciphers. I assume, the slightly older ones are still ok for a first update. Currently this control fails on Ubuntu 22 after hardening with our Ansible Collection is applied.

Signed-off-by: Martin Schurz <Martin.Schurz@t-systems.com>